### PR TITLE
Update README.md for Particle Config overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ esptool --baud 115200 --port YOUR_COM_PORT write_flash -fs 32m 0x1000 blank.bin 
 ```
 
 
-**This will not restore an Oak that has had its Particle Config overwritten** at 0x100000 and 0x201000 - a device where that has occured can be partially restored by this method but then will need its device id set via serial, and you'll need to have recorded it previously. Then connect at 115200 baud and send set\n40\n{"device-id":"123456789012345678901234"}\n where 123456789012345678901234 is replaced by your device-id. You can also send a raw POST to 192.168.0.1/set with the same JSON while connected to the AP of the Oak
+**This will not restore an Oak that has had its Particle Config overwritten** at 0x100000 and 0x201000 - a device where that has occured can be partially restored by this method but then will need its device id and particle API public key reset. Particle API will then need to be notified of the new public key that the Oak has generated.
 
-To get your device-id : access the Oak url http://192.168.0.1/device-id while connected to its AP.
+KH has written some python scripts to help with that and left the instructions here:
+https://digistump.com/board/index.php?topic=2381.msg11296#msg11296
 
 ## Force update an Oak
 


### PR DESCRIPTION
I spent 3 days trying to figure out why the Oak I had previously put microPython onto and then back to Oak firmware wasn't registering with Particle API any more after having claimed it once prior to all of that... turned out I needed to register the new public key it had generated with Particle API... something this README was totally missing. KH member in digistump board was kind enough to provide python scripts to help with all of this.